### PR TITLE
Allow short camera distances

### DIFF
--- a/src/temgymbasic/components.py
+++ b/src/temgymbasic/components.py
@@ -704,6 +704,12 @@ class DoubleDeflector(Component):
     def length(self) -> float:
         return self._second.z - self._first.z
 
+    def _set_length(self, length: float):
+        first_z = self.z - length / 2
+        second_z = self.z + length / 2
+        self.first._set_z(first_z)
+        self.second._set_z(second_z)
+
     @property
     def first(self) -> Deflector:
         return self._first


### PR DESCRIPTION
A real instrument can reach lower values than the current limit.

As a solution, move components around to make them fit.

This surfaced a secondary issue: The reference was incorrect and produced the wrong scale for very short camera length. This is now corrected, to be applied in Microscope-Calibration as well.